### PR TITLE
Add PNGIntel.com static multi-page website prototype

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,31 +1,22 @@
- (cd "$(git rev-parse --show-toplevel)" && git apply --3way <<'EOF' 
-diff --git a/README.md b/README.md
-index f1ec81d2b7bf8c5d16f32a31dc3dc0430a0053eb..ebbde3bb43d84e0047ee7b2ef1d63fe95c4b3c12 100644
---- a/README.md
-+++ b/README.md
-@@ -1,4 +1,21 @@
- 
-+# Paradox Orchard
-+
-+Paradox Orchard is a brand-new browser game prototype where you grow fruit echoes across three timelines:
-+
-+- **Past**
-+- **Present**
-+- **Future**
-+
-+You score by creating **Paradox Blooms** (the same fruit on the same row in all three timelines).
-+Each anchor increases entropy; blooms reduce it. Reach 100% entropy and the run ends.
-+
-+## Controls
-+
-+- `A` / `←`: Move active fruit left
-+- `D` / `→`: Move active fruit right
-+- `S` / `↓`: Speed up descent by one tick
-+- `Space`: Anchor the fruit immediately
-+
-+## Run locally
-+
-+Because this is plain HTML/CSS/JS, you can run it by opening `index.html` in your browser.
- 
-EOF
-)
+# PNGIntel.com Website Prototype
+
+Static multi-page website prototype for a PNG intelligence, market entry, and risk advisory platform.
+
+## Pages
+
+- `index.html` – homepage and positioning
+- `intelligence.html` – free insights / traffic engine page
+- `premium-reports.html` – premium reports and subscriptions
+- `advisory.html` – consulting services
+- `about.html` – trust-building brand story
+- `contact.html` – inquiry and consultation form
+
+## Local preview
+
+Open `index.html` directly in your browser, or run:
+
+```bash
+python3 -m http.server 8000
+```
+
+Then browse to `http://localhost:8000`.

--- a/about.html
+++ b/about.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>About | PNGIntel.com</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <header class="site-header"><div class="container nav-wrap"><a class="logo" href="index.html">PNGIntel<span>.com</span></a><nav><ul class="nav-links"><li><a href="intelligence.html">Intelligence</a></li><li><a href="premium-reports.html">Premium Reports</a></li><li><a href="advisory.html">Advisory</a></li><li><a href="about.html">About</a></li><li><a href="contact.html">Contact</a></li></ul></nav></div></header>
+  <main>
+    <section class="page-hero"><div class="container"><h1>Bridging Australia and Papua New Guinea</h1></div></section>
+    <section class="section"><div class="container narrow"><p>PNGIntel.com was created to bridge the information gap between opportunity and execution in Papua New Guinea. We combine local context with a risk-management mindset so businesses can make informed, commercially realistic decisions.</p><p>Our perspective is grounded in PNG realities and calibrated for Australian investors and operators seeking clarity, not noise.</p><div class="card"><h3>What builds trust</h3><ul><li>PNG citizen advantage and local context</li><li>Risk management and due diligence orientation</li><li>Understanding of both Australian and PNG business environments</li></ul></div></div></section>
+  </main>
+  <footer class="site-footer"><div class="container footer-grid"><p>&copy; 2026 PNGIntel.com.</p><p>About PNGIntel</p></div></footer>
+</body>
+</html>

--- a/advisory.html
+++ b/advisory.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Advisory | PNGIntel.com</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <header class="site-header"><div class="container nav-wrap"><a class="logo" href="index.html">PNGIntel<span>.com</span></a><nav><ul class="nav-links"><li><a href="intelligence.html">Intelligence</a></li><li><a href="premium-reports.html">Premium Reports</a></li><li><a href="advisory.html">Advisory</a></li><li><a href="about.html">About</a></li><li><a href="contact.html">Contact</a></li></ul></nav></div></header>
+  <main>
+    <section class="page-hero"><div class="container"><h1>Strategic Advisory Services</h1><p>Practical guidance for companies entering and operating in PNG.</p></div></section>
+    <section class="section"><div class="container list-grid"><article class="card"><h2>Market Entry Strategy</h2><p>Build a phased market entry roadmap with clear risk controls and execution checkpoints.</p></article><article class="card"><h2>Vendor Due Diligence</h2><p>Validate counterparties, partnerships, and procurement pathways before engagement.</p></article><article class="card"><h2>Investment Risk Assessment</h2><p>Assess regulatory, operational, and partner-related risks with mitigation options.</p></article></div></section>
+    <section class="section cta alt"><div class="container"><h2>Need tailored support?</h2><a class="btn btn-primary" href="contact.html">Book Consultation</a></div></section>
+  </main>
+  <footer class="site-footer"><div class="container footer-grid"><p>&copy; 2026 PNGIntel.com.</p><p>Strategic Advisory</p></div></footer>
+</body>
+</html>

--- a/contact.html
+++ b/contact.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Contact | PNGIntel.com</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <header class="site-header"><div class="container nav-wrap"><a class="logo" href="index.html">PNGIntel<span>.com</span></a><nav><ul class="nav-links"><li><a href="intelligence.html">Intelligence</a></li><li><a href="premium-reports.html">Premium Reports</a></li><li><a href="advisory.html">Advisory</a></li><li><a href="about.html">About</a></li><li><a href="contact.html">Contact</a></li></ul></nav></div></header>
+  <main>
+    <section class="page-hero"><div class="container"><h1>Contact / Consultation</h1><p>Tell us what decision you need to make in PNG and we’ll respond with next steps.</p></div></section>
+    <section class="section"><div class="container split"><form><label for="name">Name</label><input id="name" name="name" type="text" placeholder="Your name" /><label for="email">Email</label><input id="email" name="email" type="email" placeholder="you@company.com" /><label for="message">Project Brief</label><textarea id="message" name="message" rows="6" placeholder="What market, sector, or transaction are you evaluating?"></textarea><div class="btn-row"><button class="btn btn-primary" type="submit">Send Inquiry</button></div></form><aside class="panel"><h2>Direct Contact</h2><p><strong>Email:</strong> contact@pngintel.com</p><p><strong>Booking:</strong> <a href="#">Schedule consultation call</a></p><p class="muted">Replace with your preferred calendar booking URL.</p></aside></div></section>
+  </main>
+  <footer class="site-footer"><div class="container footer-grid"><p>&copy; 2026 PNGIntel.com.</p><p>Consultation & Contact</p></div></footer>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,142 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>PNGIntel.com | PNG Intelligence, Market Entry & Risk Advisory</title>
+  <meta name="description" content="Trusted intelligence for doing business in Papua New Guinea: decision-grade insights, risk analysis, and strategic advisory for confident market entry." />
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <header class="site-header">
+    <div class="container nav-wrap">
+      <a class="logo" href="index.html">PNGIntel<span>.com</span></a>
+      <nav>
+        <ul class="nav-links">
+          <li><a href="intelligence.html">Intelligence</a></li>
+          <li><a href="premium-reports.html">Premium Reports</a></li>
+          <li><a href="advisory.html">Advisory</a></li>
+          <li><a href="about.html">About</a></li>
+          <li><a href="contact.html">Contact</a></li>
+        </ul>
+      </nav>
+    </div>
+  </header>
+
+  <main>
+    <section class="hero">
+      <div class="container hero-grid">
+        <div>
+          <p class="eyebrow">PNG Intelligence Platform</p>
+          <h1>Trusted Intelligence for Doing Business in Papua New Guinea</h1>
+          <p class="lead">
+            We provide decision-grade insights, risk analysis, and verified local intelligence to help Australian businesses confidently enter and operate in PNG.
+          </p>
+          <div class="btn-row">
+            <a class="btn btn-primary" href="intelligence.html">Explore Insights (Free)</a>
+            <a class="btn btn-secondary" href="premium-reports.html">Access Premium Reports</a>
+          </div>
+        </div>
+        <aside class="hero-card">
+          <h2>Final Positioning</h2>
+          <p>We don’t give information — we give clarity, insight, and confidence to act in PNG.</p>
+        </aside>
+      </div>
+    </section>
+
+    <section class="section">
+      <div class="container narrow">
+        <h2>Making PNG Understandable for Investors and Businesses</h2>
+        <p>
+          Papua New Guinea presents significant opportunities—but navigating the market requires deep local understanding.
+          We bridge the gap between opportunity and execution by delivering structured insights, verified data, and real-world risk analysis.
+        </p>
+      </div>
+    </section>
+
+    <section class="section alt">
+      <div class="container">
+        <h2>Our Core Services</h2>
+        <div class="cards">
+          <article class="card">
+            <h3>1. Market Intelligence</h3>
+            <ul>
+              <li>Sector reports</li>
+              <li>Opportunity analysis</li>
+              <li>Economic insights</li>
+            </ul>
+          </article>
+          <article class="card">
+            <h3>2. Risk &amp; Due Diligence</h3>
+            <ul>
+              <li>Vendor verification</li>
+              <li>Market entry risk assessments</li>
+              <li>Regulatory insights</li>
+            </ul>
+          </article>
+          <article class="card">
+            <h3>3. Strategic Advisory</h3>
+            <ul>
+              <li>Market entry strategy</li>
+              <li>Local partnerships</li>
+              <li>Deal support</li>
+            </ul>
+          </article>
+        </div>
+      </div>
+    </section>
+
+    <section class="section">
+      <div class="container split">
+        <div>
+          <h2>PNG Intelligence Hub</h2>
+          <p>
+            Access premium reports, market analysis, and strategic insights designed for serious investors and decision-makers.
+          </p>
+          <ul class="checklist">
+            <li>Subscription plans for ongoing intelligence access</li>
+            <li>Sample report previews before purchase</li>
+            <li>Action-focused recommendations for market entry</li>
+          </ul>
+          <a class="btn btn-primary" href="premium-reports.html">View Premium Plans</a>
+        </div>
+        <div class="panel">
+          <h3>Sample Report</h3>
+          <p><strong>PNG Infrastructure Entry Outlook 2026</strong></p>
+          <p>Includes market sizing, political-economic risk map, and partner screening framework.</p>
+          <p class="muted">Preview available • Full report unlock via subscription or one-time purchase.</p>
+        </div>
+      </div>
+    </section>
+
+    <section class="section alt">
+      <div class="container">
+        <h2>Why Choose Us</h2>
+        <div class="reasons">
+          <p>Local PNG expertise with international perspective</p>
+          <p>Risk-focused analysis (not just information)</p>
+          <p>Verified insights, not assumptions</p>
+          <p>Independent and unbiased intelligence</p>
+        </div>
+      </div>
+    </section>
+
+    <section class="section cta">
+      <div class="container narrow">
+        <h2>Start Making Informed Decisions in PNG</h2>
+        <div class="btn-row center">
+          <a class="btn btn-primary" href="contact.html">Book a Consultation</a>
+          <a class="btn btn-secondary" href="premium-reports.html">Subscribe to Intelligence Reports</a>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <div class="container footer-grid">
+      <p>&copy; 2026 PNGIntel.com. All rights reserved.</p>
+      <p>Intelligence • Market Entry • Risk Advisory</p>
+    </div>
+  </footer>
+</body>
+</html>

--- a/intelligence.html
+++ b/intelligence.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Intelligence | PNGIntel.com</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <header class="site-header">
+    <div class="container nav-wrap">
+      <a class="logo" href="index.html">PNGIntel<span>.com</span></a>
+      <nav><ul class="nav-links"><li><a href="intelligence.html">Intelligence</a></li><li><a href="premium-reports.html">Premium Reports</a></li><li><a href="advisory.html">Advisory</a></li><li><a href="about.html">About</a></li><li><a href="contact.html">Contact</a></li></ul></nav>
+    </div>
+  </header>
+  <main>
+    <section class="page-hero"><div class="container"><h1>Intelligence</h1><p>Free content designed as your traffic engine for PNG market decision-makers.</p></div></section>
+    <section class="section"><div class="container"><h2>Latest Insights</h2><div class="list-grid"><article class="card"><h3>Port Moresby Consumer Demand Snapshot</h3><p>What demand signals indicate in 2026 for FMCG and retail entrants.</p></article><article class="card"><h3>FX & Operational Planning Brief</h3><p>Currency and operating environment considerations for Australian teams.</p></article><article class="card"><h3>Procurement Pathways in PNG</h3><p>How to approach partner and vendor qualification before committing capex.</p></article></div></div></section>
+    <section class="section alt"><div class="container"><h2>Sector Analysis</h2><div class="list-grid"><article class="card"><h3>Mining</h3><p>Project cycle visibility, supporting infrastructure, and stakeholder dynamics.</p></article><article class="card"><h3>Agriculture</h3><p>Export-value chains, processing opportunities, and logistics constraints.</p></article><article class="card"><h3>Infrastructure</h3><p>Priority development corridors and implementation risk factors.</p></article></div></div></section>
+    <section class="section"><div class="container"><h2>Market Updates</h2><p>Receive periodic updates on policy, sector movements, and risk indicators impacting market entry decisions.</p><a class="btn btn-primary" href="contact.html">Get Updates</a></div></section>
+  </main>
+  <footer class="site-footer"><div class="container footer-grid"><p>&copy; 2026 PNGIntel.com.</p><p>Intelligence • Market Entry • Risk Advisory</p></div></footer>
+</body>
+</html>

--- a/premium-reports.html
+++ b/premium-reports.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Premium Reports | PNGIntel.com</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <header class="site-header"><div class="container nav-wrap"><a class="logo" href="index.html">PNGIntel<span>.com</span></a><nav><ul class="nav-links"><li><a href="intelligence.html">Intelligence</a></li><li><a href="premium-reports.html">Premium Reports</a></li><li><a href="advisory.html">Advisory</a></li><li><a href="about.html">About</a></li><li><a href="contact.html">Contact</a></li></ul></nav></div></header>
+  <main>
+    <section class="page-hero"><div class="container"><h1>Premium PNG Market Intelligence</h1><p>Strategic reports with concise decision summaries and monetization-ready pricing.</p></div></section>
+    <section class="section"><div class="container"><h2>Featured Reports</h2><div class="list-grid"><article class="card"><h3>Infrastructure Entry Outlook</h3><p><strong>Summary:</strong> Demand map, pipeline scan, and execution risk lens.</p><p><strong>Price:</strong> AUD 499</p><a class="btn btn-primary" href="contact.html">Unlock Report</a></article><article class="card"><h3>Mining Services Opportunity Index</h3><p><strong>Summary:</strong> Procurement entry routes and partner reliability checks.</p><p><strong>Price:</strong> AUD 699</p><a class="btn btn-primary" href="contact.html">Unlock Report</a></article><article class="card"><h3>Agribusiness Value Chain Deep-Dive</h3><p><strong>Summary:</strong> Upstream/downstream bottlenecks and margin opportunity model.</p><p><strong>Price:</strong> AUD 449</p><a class="btn btn-primary" href="contact.html">Unlock Report</a></article></div></div></section>
+    <section class="section alt"><div class="container"><h2>Subscription Plans</h2><div class="list-grid"><article class="card"><h3>Monthly</h3><p>AUD 199/month</p><p>1 premium report + market update brief.</p></article><article class="card"><h3>Quarterly</h3><p>AUD 549/quarter</p><p>3 premium reports + advisory office hours.</p></article><article class="card"><h3>Enterprise</h3><p>Custom</p><p>Tailored sector intelligence + due diligence support.</p></article></div></div></section>
+  </main>
+  <footer class="site-footer"><div class="container footer-grid"><p>&copy; 2026 PNGIntel.com.</p><p>Premium Intelligence Hub</p></div></footer>
+</body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,224 @@
+:root {
+  --bg: #f6f8fc;
+  --surface: #ffffff;
+  --ink: #102033;
+  --muted: #4b5d72;
+  --brand: #0f3a72;
+  --brand-2: #1e5aa5;
+  --line: #d9e2ef;
+}
+
+* { box-sizing: border-box; }
+body {
+  margin: 0;
+  font-family: Inter, "Segoe UI", Roboto, Arial, sans-serif;
+  color: var(--ink);
+  background: var(--bg);
+  line-height: 1.6;
+}
+
+.container {
+  width: min(1120px, 92%);
+  margin: 0 auto;
+}
+
+.narrow { width: min(800px, 92%); }
+
+.site-header {
+  background: #0a274a;
+  border-bottom: 1px solid #163d6d;
+  position: sticky;
+  top: 0;
+  z-index: 10;
+}
+
+.nav-wrap {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.9rem 0;
+}
+
+.logo {
+  color: #fff;
+  text-decoration: none;
+  font-weight: 700;
+  font-size: 1.2rem;
+}
+.logo span { color: #8cc1ff; }
+
+.nav-links {
+  display: flex;
+  list-style: none;
+  gap: 1rem;
+  padding: 0;
+  margin: 0;
+}
+
+.nav-links a {
+  color: #dfeeff;
+  text-decoration: none;
+  font-weight: 500;
+}
+
+.hero {
+  background: linear-gradient(135deg, #0b2e57, #174e8f);
+  color: #fff;
+  padding: 4rem 0 3.5rem;
+}
+
+.hero-grid {
+  display: grid;
+  grid-template-columns: 2fr 1fr;
+  gap: 2rem;
+  align-items: start;
+}
+
+.eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.75rem;
+  color: #9dc8ff;
+}
+
+h1, h2, h3 { line-height: 1.25; }
+h1 { font-size: clamp(1.8rem, 4vw, 2.9rem); margin-top: 0.2rem; }
+h2 { font-size: clamp(1.5rem, 3vw, 2.1rem); margin-top: 0; }
+
+.lead {
+  font-size: 1.1rem;
+  max-width: 70ch;
+}
+
+.hero-card,
+.card,
+.panel {
+  background: var(--surface);
+  color: var(--ink);
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  padding: 1.1rem 1.2rem;
+  box-shadow: 0 10px 24px rgba(7, 28, 58, 0.08);
+}
+
+.section { padding: 3.4rem 0; }
+.section.alt { background: #eaf0f8; }
+
+.cards {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1rem;
+}
+
+.card ul,
+.checklist { margin: 0.5rem 0 0; padding-left: 1.15rem; }
+
+.split {
+  display: grid;
+  grid-template-columns: 2fr 1fr;
+  gap: 1.2rem;
+  align-items: center;
+}
+
+.reasons {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 0.8rem;
+}
+
+.reasons p {
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  padding: 0.9rem;
+  margin: 0;
+}
+
+.btn-row {
+  display: flex;
+  gap: 0.8rem;
+  flex-wrap: wrap;
+  margin-top: 1rem;
+}
+.center { justify-content: center; }
+
+.btn {
+  display: inline-block;
+  text-decoration: none;
+  border-radius: 10px;
+  padding: 0.7rem 1rem;
+  font-weight: 600;
+  border: 1px solid transparent;
+}
+
+.btn-primary {
+  background: var(--brand);
+  color: #fff;
+}
+
+.btn-secondary {
+  background: transparent;
+  color: var(--brand);
+  border-color: var(--brand);
+}
+
+.cta { text-align: center; }
+.muted { color: var(--muted); }
+
+.page-hero {
+  background: #123a6a;
+  color: #fff;
+  padding: 3rem 0;
+}
+
+.list-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 1rem;
+}
+
+.site-footer {
+  background: #081e37;
+  color: #c6d8ef;
+  padding: 1.4rem 0;
+}
+
+.footer-grid {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+form {
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  padding: 1rem;
+}
+
+label { display: block; margin: 0.6rem 0 0.2rem; font-weight: 600; }
+input, textarea {
+  width: 100%;
+  border: 1px solid #b7c8de;
+  border-radius: 8px;
+  padding: 0.65rem;
+  font: inherit;
+}
+
+@media (max-width: 900px) {
+  .hero-grid, .split, .cards, .reasons {
+    grid-template-columns: 1fr;
+  }
+
+  .nav-wrap {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.7rem;
+  }
+
+  .nav-links {
+    flex-wrap: wrap;
+    gap: 0.7rem;
+  }
+}


### PR DESCRIPTION
### Motivation
- Provide a revenue-ready marketing site and positioning for a PNG intelligence, market entry, and risk advisory platform so the brand appears professional, trusted, regional, and premium.
- Equip the project with a simple static prototype that demonstrates structure, monetisation flow (free content → premium reports → advisory) and core messaging for rapid iteration.

### Description
- Add a complete static site implemented in plain HTML/CSS, including `index.html`, `intelligence.html`, `premium-reports.html`, `advisory.html`, `about.html`, and `contact.html` with copy and layout matching the requested positioning and content pillars.
- Add a shared stylesheet `styles.css` implementing a clean white + dark blue design system, responsive grids, reusable cards, buttons, and layout primitives to match a corporate/data-driven look.
- Provide a static contact form layout and sample premium report/subscription pages to support monetisation flows and advisory CTAs without backend wiring.
- Replace the README with `README.md` documenting pages and local preview instructions (`python3 -m http.server 8000`).

### Testing
- Ran static checks with `git diff --check` to ensure no whitespace or patch issues and the check completed successfully.
- Performed a smoke-start of a local server with `python3 -m http.server 8000` (start/stop) to validate files serve correctly and the smoke check passed.
- Verified the new files are present and renderable in a static-preview workflow using the local server command above and no runtime errors were encountered.
- No automated unit tests were added because this is a static HTML/CSS prototype; manual local preview was used as the validation step.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e05307c4b883259e6b21cf5fdeb820)